### PR TITLE
Replaced ":nothing" which was removed in Rails 5.1

### DIFF
--- a/app/controllers/portfolios_controller.rb
+++ b/app/controllers/portfolios_controller.rb
@@ -12,7 +12,7 @@ class PortfoliosController < ApplicationController
       Portfolio.find(value[:id]).update(position: value[:position])
     end
 
-    render nothing: true
+    head :no_content
   end
 
   def angular


### PR DESCRIPTION
Replaced "render nothing: true" in portfolios controller with "head :no_content" because ":nothing" was removed in Rails 5.1.